### PR TITLE
Display the latest compatible version of an add-on, instead of the latest

### DIFF
--- a/src/olympia/addons/buttons.py
+++ b/src/olympia/addons/buttons.py
@@ -29,7 +29,8 @@ def install_button(context, addon, version=None,
         addon, app, lang, version=version,
         show_warning=show_warning, src=src, collection=collection, size=size,
         detailed=detailed, impala=impala,
-        show_download_anyway=show_download_anyway)
+        show_download_anyway=show_download_anyway,
+        request=request)
     installed = (request.user.is_authenticated() and
                  addon.id in request.user.mobile_addons)
     context = {
@@ -77,12 +78,13 @@ class InstallButton(object):
 
     def __init__(self, addon, app, lang, version=None,
                  show_warning=True, src='', collection=None, size='',
-                 detailed=False, impala=False, show_download_anyway=False):
+                 detailed=False, impala=False, show_download_anyway=False,
+                 request=None):
         self.addon, self.app, self.lang = addon, app, lang
         self.latest = version is None
         self.version = version
         if not self.version:
-            self.version = addon.current_version
+            (self.version, self.latest) = addon.latest_compatible_version(request, app)
         self.src = src
         self.collection = collection
         self.size = size

--- a/src/olympia/addons/templates/addons/impala/details.html
+++ b/src/olympia/addons/templates/addons/impala/details.html
@@ -88,7 +88,7 @@
     {% endif %}
   </aside>
 
-  {% set version = addon.current_version %}
+  {% set version = addon.latest_compatible_version(request, APP)[0] %}
 
   {# All this depends on the addon or version, and nothing needs the user,
      so we can cache it all against the addon. #}
@@ -143,7 +143,7 @@
 
 {% block content %}
 
-{% set version = addon.current_version %}
+{% set version = addon.latest_compatible_version(request, APP)[0] %}
 
 {% if addon.type != amo.ADDON_PERSONA %}
   {% if addon.current_previews|length > 0 %}


### PR DESCRIPTION
This checks the user agent string for Thunderbird versions numbers, and compares them to the compatible versions for the add-on. It should allow add-on authors to upload beta-compatible versions without the add-on being shown as incompatible with ESR versions. At least in the detail view, for now.