### PR TITLE
Add "restart required" flag to WebExtensions with overlays

### DIFF
--- a/src/olympia/files/utils.py
+++ b/src/olympia/files/utils.py
@@ -512,7 +512,7 @@ class ManifestJSONExtractor(object):
                 'name': self.get('name'),
                 'homepage': self.get('homepage_url'),
                 'summary': self.get('description'),
-                'is_restart_required': False,
+                'is_restart_required': self.get('legacy') is not None,
                 'apps': list(self.apps()),
                 'e10s_compatibility': amo.E10S_COMPATIBLE_WEBEXTENSION,
                 # Langpacks have strict compatibility enabled, rest of


### PR DESCRIPTION
Since overlay extensions will require a manifest.json after ESR60, the website will think they don't require a restart and not show the "restart required" flag. There's some extension versions already that are missing the flag, but I don't know if it's worth going back to find them all and set it.