### PR TITLE
Stop considering some extensions for auto-approval

### DIFF
--- a/src/olympia/reviewers/management/commands/auto_approve.py
+++ b/src/olympia/reviewers/management/commands/auto_approve.py
@@ -39,12 +39,14 @@ class Command(BaseCommand):
         """Return a queryset with the Version instances that should be
         considered for auto approval."""
         return (Version.objects.filter(
+            files__is_restart_required=False,
             addon__type__in=(
                 amo.ADDON_EXTENSION, amo.ADDON_LPAPP, amo.ADDON_DICT),
             addon__disabled_by_user=False,
             addon__status__in=(amo.STATUS_PUBLIC, amo.STATUS_NOMINATED),
             files__status=amo.STATUS_AWAITING_REVIEW,
-            files__is_webextension=True)
+            files__is_webextension=True,
+            files__is_experiment=False)
             .order_by('nomination', 'created').distinct())
 
     def handle(self, *args, **options):

--- a/src/olympia/reviewers/management/commands/auto_approve.py
+++ b/src/olympia/reviewers/management/commands/auto_approve.py
@@ -46,8 +46,9 @@ class Command(BaseCommand):
             addon__status__in=(amo.STATUS_PUBLIC, amo.STATUS_NOMINATED),
             files__status=amo.STATUS_AWAITING_REVIEW,
             files__is_webextension=True,
-            files__is_experiment=False)
-            .order_by('nomination', 'created').distinct())
+            # To require approval of WebExt experiments, uncomment this line.
+            # files__is_experiment=False
+        ).order_by('nomination', 'created').distinct())
 
     def handle(self, *args, **options):
         """Command entry point."""

--- a/src/olympia/reviewers/views.py
+++ b/src/olympia/reviewers/views.py
@@ -506,6 +506,8 @@ def _queue(request, TableObj, tab, qs=None, unlisted=False,
             qs = qs.filter(
                 Q(addon_type_id=amo.ADDON_STATICTHEME) |
                 Q(**{'files.is_webextension': False}) |
+                Q(**{'files.is_experiment': True}) |
+                Q(**{'files.is_restart_required': True}) |
                 Q(**{'addons_addonreviewerflags.auto_approval_disabled': True})
             )
 

--- a/src/olympia/reviewers/views.py
+++ b/src/olympia/reviewers/views.py
@@ -506,7 +506,8 @@ def _queue(request, TableObj, tab, qs=None, unlisted=False,
             qs = qs.filter(
                 Q(addon_type_id=amo.ADDON_STATICTHEME) |
                 Q(**{'files.is_webextension': False}) |
-                Q(**{'files.is_experiment': True}) |
+                # To require approval of WebExt experiments, uncomment this line.
+                # Q(**{'files.is_experiment': True}) |
                 Q(**{'files.is_restart_required': True}) |
                 Q(**{'addons_addonreviewerflags.auto_approval_disabled': True})
             )


### PR DESCRIPTION
Based on what @Sancus just told me, this isn't going to work and will leave some extensions in No Man's Land, but here it is.