### PR TITLE
Fix #83: Never return a latest version that has no associated files.

### DIFF
--- a/src/olympia/addons/models.py
+++ b/src/olympia/addons/models.py
@@ -871,7 +871,7 @@ class Addon(OnChangeMixin, ModelBase):
                 app_version_int = version_int(version_match.group(1))
 
         for v in self.versions.all():
-            if not v.is_public():
+            if not v.is_public() or not v.all_files:
                 continue
             compat = v.compatible_apps.get(app)
             if compat is None or compat.min.version_int > app_version_int:


### PR DESCRIPTION
This kind of sucks. There's a lot of code that assumes it's impossible for there to be listed, public versions with no files but... there are addons that have versions in this state.

Newer versions should always have files, so, this just avoids iterating over older versions that don't have any for whatever weird reason. The alternative is trying to fix every function that assumes a version should have files, which is just too many changes.