### PR TITLE
Link to TB specific resources

### DIFF
--- a/src/olympia/devhub/templates/devhub/new-landing/components/overview.html
+++ b/src/olympia/devhub/templates/devhub/new-landing/components/overview.html
@@ -9,6 +9,6 @@
         you already have all the necessary skills to make a great add-on.
       {% endtrans %}
     </p>
-    <a href="https://developer.mozilla.org/en-US/Add-ons" class="Button Button--primary">{{ _('Learn How to Make an Add-on') }}</a>
+    <a href="https://developer.thunderbird.net/add-ons/about-add-ons" class="Button Button--primary">{{ _('Learn How to Make an Add-on') }}</a>
   </div>
 </section>

--- a/src/olympia/templates/copyright.html
+++ b/src/olympia/templates/copyright.html
@@ -12,7 +12,7 @@
       </a>
       {% block extra_footer_links %}
         &nbsp;|&nbsp;<a href="https://status.mozilla.org">{{ _('Site Status')}}</a>
-        &nbsp;|&nbsp;<a href="https://developer.mozilla.org/en-US/Add-ons/AMO/Policy/Contact">{{ _('Report a bug')}}</a>
+        &nbsp;|&nbsp;<a href="https://github.com/thundernest/addons-server/issues/new">{{ _('Report a bug')}}</a>
       {% endblock %}
     {% endblock %}
   </p>

--- a/src/olympia/templates/footer.html
+++ b/src/olympia/templates/footer.html
@@ -2,9 +2,9 @@
   <ul>
     <li>{{ _('get to know <b>add-ons</b>') }}</li>
     <li><a href="{{ url('pages.about') }}">{{ _('About') }}</a></li>
-    <li><a href="http://blog.mozilla.com/addons">{{ _('Blog') }}</a></li>
+    <li><a href="https://blog.mozilla.org/thunderbird/">{{ _('Blog') }}</a></li>
     <li class="footer-devhub-link"><a href="{{ url('devhub.index') }}">{{ _('Developer Hub') }}</a></li>
-    <li><a href="https://discourse.mozilla-community.org/c/add-ons">{{ _('Forum') }}</a></li>
+    <li><a href="https://discourse.mozilla.org/c/thunderbird/addons">{{ _('Forum') }}</a></li>
   </ul>
 </div>
 <div id="footer-content">


### PR DESCRIPTION
Fixes #85 

Replaces links to things like the Firefox Add-on docs or how to contact AMO staff with links that match better with Thunderbird. There are more occurrences of this (especially in the developer hub, things like the blog post feed).