### PR TITLE
Don't show restart-required flag for bootstrapped add-ons

### DIFF
--- a/src/olympia/files/utils.py
+++ b/src/olympia/files/utils.py
@@ -526,11 +526,15 @@ class ManifestJSONExtractor(object):
             data.update(self.certinfo.parse())
 
         if not minimal:
+            restart_required = False
+            legacy = self.get('legacy')
+            if legacy is not None and ('type' not in legacy or legacy['type'] != 'bootstrap'):
+                restart_required = True
             data.update({
                 'name': self.get('name'),
                 'homepage': self.get('homepage_url'),
                 'summary': self.get('description'),
-                'is_restart_required': self.get('legacy') is not None,
+                'is_restart_required': restart_required,
                 'apps': list(self.apps()),
                 'e10s_compatibility': amo.E10S_COMPATIBLE_WEBEXTENSION,
                 # Langpacks have strict compatibility enabled, rest of


### PR DESCRIPTION
DON'T LAND THIS - auto-approval will start approving bootstrapped add-ons if you do.

I'm still thinking of a way around that problem that doesn't involve changes to the database.