### PR TITLE
Fix #90: Restrict json update format to TB versions after 60.

### DIFF
--- a/services/update.py
+++ b/services/update.py
@@ -87,9 +87,10 @@ class Update(object):
         # because we've seen issues with Seamonkey and Thunderbird.
         # https://github.com/mozilla/addons-server/issues/7223
         app = applications.APP_GUIDS.get(self.data.get('appID'))
-        return app and app.id in (applications.FIREFOX.id,
-                                  applications.ANDROID.id,
-                                  applications.THUNDERBIRD.id)
+        version = self.data.get('currentAppVersion')
+        if app and version:
+            return app.id == applications.THUNDERBIRD.id and int(version.split('.')[0]) > 60
+        return False
 
     def is_valid(self):
         # If you accessing this from unit tests, then before calling

--- a/src/olympia/files/utils.py
+++ b/src/olympia/files/utils.py
@@ -533,9 +533,9 @@ class ManifestJSONExtractor(object):
                 'is_restart_required': self.get('legacy') is not None,
                 'apps': list(self.apps()),
                 'e10s_compatibility': amo.E10S_COMPATIBLE_WEBEXTENSION,
-                # Langpacks have strict compatibility enabled, rest of
+                # Langpacks and legacy add-ons have strict compatibility enabled, rest of
                 # webextensions don't.
-                'strict_compatibility': data['type'] == amo.ADDON_LPAPP,
+                'strict_compatibility': self.get('legacy') is not None or data['type'] == amo.ADDON_LPAPP,
                 'default_locale': self.get('default_locale'),
                 'is_experiment': self.is_experiment,
             })


### PR DESCRIPTION
This removes support for Firefox from this method but it doesn't matter because we don't have any Firefox add-ons.

SeaMonkey never gets JSON because it doesn't support it.
