### PR TITLE
Fix wrong DE l10n of "Part of these collections"

### DIFF
--- a/locale/de/LC_MESSAGES/django.po
+++ b/locale/de/LC_MESSAGES/django.po
@@ -482,7 +482,7 @@ msgid "Related Categories"
 msgstr "Verwandte Kategorien"
 
 msgid "Part of these Collections"
-msgstr "Teile dieser Sammlungen"
+msgstr "Teil dieser Sammlungen"
 
 #, python-format
 msgid "Other add-ons by %(author)s"


### PR DESCRIPTION
Fixes #183.

German for "Part of these collections" was wrongly translated as "Teile dieser Sammlungen". That would translate back to "Parts of these collections", which distorts the meaning with "parts" being plural. Let's stick with singular! -> "Teil dieser Sammlungen"