### PR TITLE
Fix outdated redirect url

### DIFF
--- a/src/olympia/addons/tests/test_models.py
+++ b/src/olympia/addons/tests/test_models.py
@@ -2614,9 +2614,6 @@ class TestAddonFromUpload(UploadTest):
         assert addon.default_locale == 'en-US'
 
 
-REDIRECT_URL = 'https://outgoing.prod.mozaws.net/v1/'
-
-
 class TestFrozenAddons(TestCase):
 
     def test_immediate_freeze(self):

--- a/src/olympia/conf/dev/settings.py
+++ b/src/olympia/conf/dev/settings.py
@@ -99,8 +99,6 @@ CEF_PRODUCT = STATSD_PREFIX
 
 NEW_FEATURES = True
 
-REDIRECT_URL = 'https://outgoing.stage.mozaws.net/v1/'
-
 ADDONS_LINTER_BIN = 'node_modules/.bin/addons-linter'
 
 XSENDFILE_HEADER = 'X-Accel-Redirect'

--- a/src/olympia/conf/stage/settings.py
+++ b/src/olympia/conf/stage/settings.py
@@ -93,8 +93,6 @@ CEF_PRODUCT = STATSD_PREFIX
 
 NEW_FEATURES = True
 
-REDIRECT_URL = 'https://outgoing.stage.mozaws.net/v1/'
-
 ADDONS_LINTER_BIN = 'node_modules/.bin/addons-linter'
 
 XSENDFILE_HEADER = 'X-Accel-Redirect'

--- a/src/olympia/lib/settings_base.py
+++ b/src/olympia/lib/settings_base.py
@@ -1085,7 +1085,7 @@ VAMO_URL = 'https://versioncheck.addons.mozilla.org'
 
 
 # Outgoing URL bouncer
-REDIRECT_URL = 'https://outgoing.prod.mozaws.net/v1/'
+REDIRECT_URL = 'https://prod.outgoing.prod.webservices.mozgcp.net/v1/'
 REDIRECT_SECRET_KEY = env('REDIRECT_SECRET_KEY', default='')
 
 # Allow URLs from these servers. Use full domain names.

--- a/src/olympia/lib/settings_base.py
+++ b/src/olympia/lib/settings_base.py
@@ -1085,7 +1085,7 @@ VAMO_URL = 'https://versioncheck.addons.mozilla.org'
 
 
 # Outgoing URL bouncer
-REDIRECT_URL = 'https://prod.outgoing.prod.webservices.mozgcp.net/v1/'
+REDIRECT_URL = env('REDIRECT_URL', default='https://prod.outgoing.prod.webservices.mozgcp.net/v1/')
 REDIRECT_SECRET_KEY = env('REDIRECT_SECRET_KEY', default='')
 
 # Allow URLs from these servers. Use full domain names.


### PR DESCRIPTION
Fixes #203.

Currently uses Mozilla's new redirect url, but if the team would like to instead use their own redirect url, let me know.