### PR TITLE
Fixes for local docker development

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -90,4 +90,4 @@ ENV CLEANCSS_BIN /deps/node_modules/.bin/cleancss
 ENV LESS_BIN /deps/node_modules/.bin/lessc
 ENV UGLIFY_BIN /deps/node_modules/.bin/uglifyjs
 ENV ADDONS_LINTER_BIN /deps/node_modules/.bin/addons-linter
-RUN npm cache clean -f && npm install -g n && n 12.22.4
+RUN npm cache clean -f && npm install -g n && /deps/bin/n 12.22.4

--- a/Dockerfile.mac-arm
+++ b/Dockerfile.mac-arm
@@ -1,0 +1,97 @@
+FROM python:2.7.18-slim-stretch
+
+ENV PYTHONDONTWRITEBYTECODE=1
+
+# Allow scripts to detect we're running in our own container
+RUN touch /addons-server-docker-container
+
+# Add nodesource repository and requirements
+ADD docker/nodesource.gpg.key /etc/pki/gpg/GPG-KEY-nodesource
+RUN apt-get update && apt-get install -y \
+        apt-transport-https              \
+        gnupg2                           \
+    && rm -rf /var/lib/apt/lists/*
+RUN cat /etc/pki/gpg/GPG-KEY-nodesource | apt-key add -
+ADD docker/debian-stretch-nodesource-repo /etc/apt/sources.list.d/nodesource.list
+ADD docker/debian-stretch-backports-repo /etc/apt/sources.list.d/backports.list
+
+RUN apt-get update && apt-get install -y \
+        # General (dev-) dependencies
+        bash-completion \
+        build-essential \
+        curl \
+        libjpeg-dev \
+        libsasl2-dev \
+        libxml2-dev \
+        libxslt-dev \
+        locales \
+        zlib1g-dev \
+        libffi-dev \
+        libssl-dev \
+        #python-dev \
+        #python-pip \
+        nodejs \
+        # Git, because we're using git-checkout dependencies
+        git \
+        # Dependencies for mysql-python
+        mysql-client \
+        default-libmysqlclient-dev \
+        swig \
+        gettext \
+        # Use rsvg-convert to render our static theme previews
+        librsvg2-bin \
+        # Use pngcrush to optimize the PNGs uploaded by developers
+        pngcrush \
+        # our makefile and ui-tests require uuid to be installed
+        uuid \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN apt-get update && apt-get -t stretch-backports install -y \
+        # For git-based files storage backend
+        libgit2-dev \
+    && rm -rf /var/lib/apt/lists/*
+
+# Compile required locale
+RUN localedef -i en_US -f UTF-8 en_US.UTF-8
+
+# Set the locale. This is mainly so that tests can write non-ascii files to
+# disk.
+ENV LANG en_US.UTF-8
+ENV LC_ALL en_US.UTF-8
+
+COPY . /code
+WORKDIR /code
+
+ENV PIP_BUILD=/deps/build/
+ENV PIP_CACHE_DIR=/deps/cache/
+ENV PIP_SRC=/deps/src/
+ENV NPM_CONFIG_PREFIX=/deps/
+ENV SWIG_FEATURES="-D__x86_64__"
+
+RUN rm -rf /deps/build/ /deps/cache/
+
+RUN /usr/local/bin/python -m pip install --upgrade pip
+
+# Install all python requires
+RUN mkdir -p /deps/{build,cache,src}/ && \
+    ln -s /code/package.json /deps/package.json && \
+    make update_deps && \
+    rm -rf /deps/build/ /deps/cache/
+
+# Preserve bash history across image updates.
+# This works best when you link your local source code
+# as a volume.
+ENV HISTFILE /code/docker/artifacts/bash_history
+
+# Configure bash history.
+ENV HISTSIZE 50000
+ENV HISTIGNORE ls:exit:"cd .."
+
+# This prevents dupes but only in memory for the current session.
+ENV HISTCONTROL erasedups
+
+ENV CLEANCSS_BIN /deps/node_modules/.bin/cleancss
+ENV LESS_BIN /deps/node_modules/.bin/lessc
+ENV UGLIFY_BIN /deps/node_modules/.bin/uglifyjs
+ENV ADDONS_LINTER_BIN /deps/node_modules/.bin/addons-linter
+RUN npm cache clean -f && npm install -g n && /deps/bin/n 12.22.4

--- a/Makefile-docker
+++ b/Makefile-docker
@@ -89,11 +89,14 @@ populate_data:
 	python manage.py reindex --wipe --force --noinput
 	python manage.py generate_addons --app firefox $(NUM_ADDONS)
 	python manage.py generate_addons --app android $(NUM_ADDONS)
-	python manage.py generate_themes $(NUM_THEMES)
+	python manage.py generate_addons --app thunderbird $(NUM_ADDONS)
+	python manage.py generate_themes --app firefox $(NUM_THEMES)
+	python manage.py generate_themes --app thunderbird $(NUM_THEMES)
 	# These add-ons are specifically useful for the addons-frontend
 	# homepage. You may have to re-run this, in case the data there
 	# changes.
-	python manage.py generate_default_addons_for_frontend
+	# Stubbed out, uses pyfxa which is not pulled in.
+	#python manage.py generate_default_addons_for_frontend
 
 	# Now that addons have been generated, reindex.
 	python manage.py reindex --force --noinput
@@ -176,4 +179,7 @@ perf-tests: setup-ui-tests
 	pip install --progress-bar=off --no-deps -r requirements/perftests.txt
 	locust --no-web -c 1 -f tests/performance/locustfile.py --host "http://olympia.test"
 
-initialize: update_deps initialize_db update_assets populate_data
+finished:
+	@echo "Done!"
+
+initialize: update_deps initialize_db update_assets populate_data finished

--- a/docker-compose.mac-arm.yml
+++ b/docker-compose.mac-arm.yml
@@ -1,0 +1,113 @@
+version: "2.3"
+
+x-env-mapping: &env
+  environment:
+    - CELERY_BROKER_URL=amqp://olympia:olympia@rabbitmq/olympia
+    - CELERY_RESULT_BACKEND=redis://redis:6379/1
+    - DATABASES_DEFAULT_URL=mysql://root:@mysqld/olympia
+    - ELASTICSEARCH_LOCATION=elasticsearch:9200
+    - MEMCACHE_LOCATION=memcached:11211
+    - MYSQL_DATABASE=olympia
+    - MYSQL_ROOT_PASSWORD=docker
+    - OLYMPIA_SITE_URL=http://olympia.test
+    - PYTHONDONTWRITEBYTECODE=1
+    - PYTHONUNBUFFERED=1
+    - RECURSION_LIMIT=10000
+    - TERM=xterm-256color
+
+services:
+  worker: &worker
+    <<: *env
+    image: addons/addons-server
+    command: supervisord -n -c /code/docker/supervisor-celery.conf
+    entrypoint: ./scripts/start-docker.sh
+    volumes:
+      - .:/code
+    extra_hosts:
+     - "olympia.test:127.0.0.1"
+
+  web:
+    <<: *worker
+    command: supervisord -n -c /code/docker/supervisor.conf
+
+  nginx:
+    image: addons/addons-nginx
+    volumes:
+      - ./static:/srv/static
+      - ./site-static:/srv/site-static
+      - ./user-media/:/srv/user-media
+
+  memcached:
+    image: memcached:1.4
+
+  mysqld:
+    image: mysql:5.7
+    platform: "linux/amd64"
+    ports:
+      # Expose default port, so we can connect it to for local development
+      - "3306:3306"
+    environment:
+      - MYSQL_ALLOW_EMPTY_PASSWORD=yes
+      - MYSQL_DATABASE=olympia
+
+  elasticsearch:
+    image: docker.elastic.co/elasticsearch/elasticsearch:5.4.1
+    platform: "linux/amd64"
+    environment:
+      # Disable all xpack related features to avoid unrelated logging
+      # in docker logs. https://github.com/mozilla/addons-server/issues/8887
+      # This also avoids us to require authentication for local development
+      # which simplifies the setup.
+      - xpack.security.enabled=false
+      - xpack.monitoring.enabled=false
+      - xpack.graph.enabled=false
+      - xpack.watcher.enabled=false
+      - "discovery.type=single-node"
+      - "ES_JAVA_OPTS=-Xms512m -Xmx512m"
+      # M1 mac emulation doesn't support this feature
+      - bootstrap.system_call_filter=false
+    mem_limit: 2g
+
+  redis:
+    image: redis:latest #:2.8
+
+  rabbitmq:
+    image: rabbitmq:3.8 #:3.5
+    hostname: olympia
+    expose:
+      - "5672"
+    environment:
+      - RABBITMQ_DEFAULT_USER=olympia
+      - RABBITMQ_DEFAULT_PASS=olympia
+      - RABBITMQ_DEFAULT_VHOST=olympia
+
+  autograph:
+    image: mozilla/autograph:2.3.0
+
+  selenium-firefox:
+    <<: *env
+    image: b4handjr/selenium-firefox
+    volumes:
+      - .:/code
+    expose:
+      - "4444"
+    ports:
+      - "5900"
+    shm_size: 2g
+    links:
+      - "addons-frontend:olympia-frontend.test"
+      - "nginx:olympia.test"
+
+  addons-frontend:
+    <<: *env
+    environment:
+      - HOSTNAME=uitests
+      - WEBPACK_SERVER_HOST=olympia-frontend.test
+      - FXA_CONFIG=default
+    image: addons/addons-frontend
+    ports:
+      - "3000:3000"
+      - "3001:3001"
+    command: yarn amo:ui-tests
+    links:
+      - "nginx:olympia.test"

--- a/src/olympia/addons/templates/addons/impala/details.html
+++ b/src/olympia/addons/templates/addons/impala/details.html
@@ -94,7 +94,7 @@
      so we can cache it all against the addon. #}
   <section class="primary addon-description-header">
     <div id="addon" class="island c" role="main" data-id="{{ addon.id }}">
-    {% if addon.type == 10 and addon.current_previews.count() %}
+    {% if addon.type == 10 and addon.current_previews.count() > 0 %}
       <div id="theme-preview-details" style="background-image:url('{{ addon.current_previews[0].image_url }}')"></div>
     {% endif %}
       <hgroup>

--- a/src/olympia/addons/templates/addons/impala/details.html
+++ b/src/olympia/addons/templates/addons/impala/details.html
@@ -94,7 +94,7 @@
      so we can cache it all against the addon. #}
   <section class="primary addon-description-header">
     <div id="addon" class="island c" role="main" data-id="{{ addon.id }}">
-    {% if addon.type == 10 %}
+    {% if addon.type == 10 and addon.current_previews.count() %}
       <div id="theme-preview-details" style="background-image:url('{{ addon.current_previews[0].image_url }}')"></div>
     {% endif %}
       <hgroup>

--- a/src/olympia/addons/templates/addons/impala/listing/items.html
+++ b/src/olympia/addons/templates/addons/impala/listing/items.html
@@ -2,7 +2,7 @@
 {% for addon in addons %}
   <div class="item addon">
     <div class="info">
-    {% if addon.type == 10 %}
+    {% if addon.type == 10 and addon.current_previews.count() > 0 %}
       <img src="{{ addon.current_previews[0].image_url }}" width="442px" height="60px">
     {% endif %}
       <h3>

--- a/src/olympia/landfill/management/commands/generate_themes.py
+++ b/src/olympia/landfill/management/commands/generate_themes.py
@@ -19,7 +19,7 @@ class Command(BaseCommand):
 
     Usage:
 
-        python manage.py generate_themes <num_themes> [--owner <email>]
+        python manage.py generate_themes <num_themes> [--owner <email>] [--app <name>]
 
     """
 
@@ -32,6 +32,10 @@ class Command(BaseCommand):
             '--owner', action='store', dest='email',
             default='nobody@mozilla.org',
             help="Specific owner's email to be created.")
+        parser.add_argument(
+            '--app', action='store', dest='app_name',
+            default='firefox',
+            help="Specific application targeted by add-ons creation.")
 
     def handle(self, *args, **kwargs):
         if not settings.DEBUG:
@@ -39,6 +43,7 @@ class Command(BaseCommand):
                                'DEBUG setting set to True.')
         num = int(kwargs.get('num'))
         email = kwargs.get('email')
+        app = kwargs.get('app_name')
 
         with translation.override(settings.LANGUAGE_CODE):
-            generate_themes(num, email)
+            generate_themes(num, email, app)

--- a/src/olympia/users/management/commands/createsuperuser.py
+++ b/src/olympia/users/management/commands/createsuperuser.py
@@ -75,6 +75,8 @@ and email address and that's it.
             except exceptions.ValidationError as exc:
                 raise CommandError('; '.join(exc.messages))
         else:
+            # During docker setup this can be a tad confusing, so specify what the prompts are for.
+            print("Please enter credentials for the new superuser:")
             user_data = {
                 field_name: self.get_value(field_name)
                 for field_name in self.required_fields


### PR DESCRIPTION
This does not resolve an existing issue, but if there's further changes needed I can do that.

Here's some initial fixes/changes to get the local addons-server docker file to build and initialize properly. (At least on my Linux install.) I'm currently able to browse extensions and themes, which is good enough for someone to come in, make changes, test them, and push up a PR.

Test suite doesn't exactly pass with flying colours right now:
`1383 failed, 4384 passed, 3 xfailed, 26 warnings in 1290.93 seconds`

There's a few other considerations:
- addons-frontend is not used by Thunderbird, and can be removed from docker-compose.
- Readme could be clearer that you need to build the image locally, and not rely on the remote image.
- GenerateAddonsSerializer used in generate_default_addons_for_frontend, seem to require fxa (from pyfxa I assume.) I've stubbed that out for now. Not sure if we even need that particular setup function.
- As far as I can see, there's no documentation on getting oauth working for local dev. 

