### PR TITLE
Only use three digits for the major version when an `*` is found.

### DIFF
--- a/src/olympia/versions/compare.py
+++ b/src/olympia/versions/compare.py
@@ -50,8 +50,11 @@ def version_dict(version):
         for letter in letters:
             d[letter] = d[letter] if d[letter] else None
         for num in numbers:
-            if d[num] == '*':
+            # We only support triple digits on major versions right now.
+            if d[num] == '*' and num == "major":
                 d[num] = 999
+            elif d[num] == '*':
+                d[num] = 99
             else:
                 d[num] = int(d[num]) if d[num] else None
     else:


### PR DESCRIPTION
Fall back to two digits for any other version.

This ensures the version deconstruction will work correctly. (This probably doesn't occur very often, if at all though.)

-- 

Related issue: https://github.com/thundernest/addons-server/issues/184

Context:

I've originally fixed this in my test-fixes branch.

Our version deconstruction function is as follows:
```
def dict_from_int(version_int):
    """Converts a version integer into a dictionary with major/minor/...
    info."""
    d = {}
    rem = version_int
    (rem, d['pre_ver']) = divmod(rem, 100)
    (rem, d['pre']) = divmod(rem, 10)
    (rem, d['alpha_ver']) = divmod(rem, 100)
    (rem, d['alpha']) = divmod(rem, 10)
    (rem, d['minor3']) = divmod(rem, 100)
    (rem, d['minor2']) = divmod(rem, 100)
    (rem, d['minor1']) = divmod(rem, 100)
    d['major'] = rem
    d['pre'] = None if d['pre'] else 'pre'
    d['alpha'] = {0: 'a', 1: 'b'}.get(d['alpha'])

    return d
```
It's only possible to grab two digits from versions other than the major version. Using three digits for the minor versions could cause incorrect subsequent version reads. 
