### PR TITLE
Also remove any privileged errors on a super fresh addons linter result.

### DIFF
--- a/src/olympia/devhub/tasks.py
+++ b/src/olympia/devhub/tasks.py
@@ -715,7 +715,7 @@ def run_validator(path, for_appversions=None, test_all_tiers=False,
 
 
 def run_addons_linter(path, listed=True, is_experiment=False):
-    from .utils import fix_addons_linter_output
+    from .utils import fix_addons_linter_output, remove_privileged_errors
 
     args = [
         settings.ADDONS_LINTER_BIN,
@@ -766,7 +766,10 @@ def run_addons_linter(path, listed=True, is_experiment=False):
 
     parsed_data = json.loads(output)
 
-    result = json.dumps(fix_addons_linter_output(parsed_data, listed))
+    fixed_data = fix_addons_linter_output(parsed_data, listed)
+
+    # Remove any privileged errors
+    result = json.dumps(remove_privileged_errors(fixed_data))
     track_validation_stats(result, addons_linter=True)
 
     return result

--- a/src/olympia/devhub/utils.py
+++ b/src/olympia/devhub/utils.py
@@ -70,6 +70,10 @@ def remove_privileged_errors(validation):
             # Prepend to the list, this will ensure our positional pops work correctly
             to_remove.insert(0, index)
 
+    # If there's nothing to remove, then don't even bother
+    if len(to_remove) == 0:
+        return validation
+
     # Iterate and remove the specific items, we're iterating in reverse order here.
     for index in to_remove:
         validation['messages'].pop(index)


### PR DESCRIPTION
Resolves #216 

Difference in my local setup vs staging/production. Oops. 

`run_addons_linter` calls a `fix_addons_linter_output` which is also called in another area for the validation results. (Where I originally put my function) That other area happens to save the validation results after it's processed, but on staging/prod it doesn't seem to do so. Weird.

So let's just remove the privileged errors in `run_addons_linter`, and that will solve our headaches.