### PR TITLE
Bugs/218 provide latest compatiable version hash for downloads

### DIFF
--- a/src/olympia/addons/models.py
+++ b/src/olympia/addons/models.py
@@ -870,12 +870,16 @@ class Addon(OnChangeMixin, ModelBase):
                  self.id, key))
 
     def latest_compatible_version(self, request, app):
+        """Retrieve the latest compatible version of this addon given the Thunderbird version,
+        which is retrieved by the latest product version, or user agent string.
+
+        Defaults to the current version
+        """
         if app is not THUNDERBIRD:
             return self.current_version, True
 
         app_version = product_details.thunderbird_versions['LATEST_THUNDERBIRD_VERSION']
         app_version_int = version_int(app_version)
-        latest = True
 
         if request is not None:
             user_agent = request.META.get('HTTP_USER_AGENT', '')
@@ -886,12 +890,18 @@ class Addon(OnChangeMixin, ModelBase):
         for v in self.versions.all():
             if not v.is_public() or not v.all_files:
                 continue
+
             compat = v.compatible_apps.get(app)
-            if compat is None or compat.min.version_int > app_version_int:
-                latest = False
-                continue
-            if v.is_compatible_by_default or compat.max.version_int >= app_version_int:
-                return v, latest
+            within_version_range = False
+
+            # Check if we're within compat versions
+            if compat is not None:
+                within_version_range = compat.min.version_int <= app_version_int and compat.max.version_int >= app_version_int
+
+            # Is this version compatible?
+            if v.is_compatible_by_default or within_version_range:
+                return v, v == self.current_version
+
 
         return self.current_version, True
 


### PR DESCRIPTION
Resolves #218 

Adjusts `latest_compatible_version` to return the correct version and correct `latest` flag. Previous code only flipped `latest` to False if the current version was less than the min version. Which ignored situations where the app version could be above the version range. 

The latest flag is only used in one spot, and that spot is for Download buttons. So chances of this change affecting a large part of ATN is minimal.

Reference:
`is_compatible_by_default` returns True if `file.binary_components` or `file.strict_compatibility` is False on every file associated with that version. 

