### PR TITLE
Remove an `overflow-x: hidden` from restyle.less (Fixes #224)

### DIFF
--- a/static/css/restyle/restyle.less
+++ b/static/css/restyle/restyle.less
@@ -45,7 +45,6 @@ body.restyle {
   font-style: normal;
   line-height: 1.5;
   min-width: @containerWidth;
-  overflow-x: hidden;
 }
 
 h1,


### PR DESCRIPTION
Fixes #224 

- Allow the user to freely scroll across an entirely new axis.
- This was probably in place for the "Go to mobile site!" banner.

We should maybe also remove that "Go to mobile site addons" banner that pops up, as I don't think that works on ATN. 