### PR TITLE
Add a command and associated task to clean up old outgoing urls

### DIFF
--- a/src/olympia/conf/dev/settings.py
+++ b/src/olympia/conf/dev/settings.py
@@ -99,7 +99,7 @@ CEF_PRODUCT = STATSD_PREFIX
 
 NEW_FEATURES = True
 
-REDIRECT_URL = 'https://outgoing.stage.mozaws.net/v1/'
+REDIRECT_URL = ''
 
 ADDONS_LINTER_BIN = 'node_modules/.bin/addons-linter'
 

--- a/src/olympia/conf/stage/settings.py
+++ b/src/olympia/conf/stage/settings.py
@@ -93,7 +93,7 @@ CEF_PRODUCT = STATSD_PREFIX
 
 NEW_FEATURES = True
 
-REDIRECT_URL = 'https://outgoing.stage.mozaws.net/v1/'
+REDIRECT_URL = ''
 
 ADDONS_LINTER_BIN = 'node_modules/.bin/addons-linter'
 

--- a/src/olympia/lib/settings_base.py
+++ b/src/olympia/lib/settings_base.py
@@ -1085,7 +1085,7 @@ VAMO_URL = 'https://versioncheck.addons.mozilla.org'
 
 
 # Outgoing URL bouncer
-REDIRECT_URL = 'https://outgoing.prod.mozaws.net/v1/'
+REDIRECT_URL = ''
 REDIRECT_SECRET_KEY = env('REDIRECT_SECRET_KEY', default='')
 
 # Allow URLs from these servers. Use full domain names.

--- a/src/olympia/translations/management/commands/clean_outgoing_urls.py
+++ b/src/olympia/translations/management/commands/clean_outgoing_urls.py
@@ -1,0 +1,61 @@
+# -*- coding: utf-8 -*-
+from celery import group
+from django.core.management.base import BaseCommand
+from olympia.amo.utils import chunked
+
+from olympia.addons.models import Addon
+from olympia.bandwagon.models import CollectionAddon
+from olympia.translations.tasks import clean_outgoing_urls
+from olympia.versions.models import Version, License
+
+
+class Command(BaseCommand):
+    help = 'Clean up any old outgoing urls from the translations table.'
+
+    def add_arguments(self, parser):
+        """Handle command arguments."""
+        parser.add_argument(
+            '--dry-run', action='store_true', dest='dry_run',
+            help='Run this command without applying the results to the database.')
+
+
+    def purified_translations(self):
+        """Retrieve a list of ids for fields that fall under the PurifiedField class"""
+        # Addon
+        id_list = list(Addon.objects.filter(description_id__isnull=False).values_list('description_id', flat=True))
+        id_list.extend(list(Addon.objects.filter(developer_comments_id__isnull=False).values_list('developer_comments_id', flat=True)))
+        id_list.extend(list(Addon.objects.filter(eula_id__isnull=False).values_list('eula_id', flat=True)))
+        id_list.extend(list(Addon.objects.filter(privacy_policy_id__isnull=False).values_list('privacy_policy_id', flat=True)))
+
+        # Version
+        id_list.extend(list(Version.objects.filter(releasenotes_id__isnull=False).values_list('releasenotes_id', flat=True)))
+
+        return id_list
+
+
+    def linkified_translations(self):
+        """Retrieve a list of ids for fields that fall under the LinkifiedField class"""
+        # Addon
+        id_list = list(Addon.objects.filter(summary_id__isnull=False).values_list('summary_id', flat=True))
+
+        # Collection Addon
+        id_list.extend(list(CollectionAddon.objects.filter(comments_id__isnull=False).values_list('comments_id', flat=True)))
+
+        # License
+        id_list.extend(list(License.objects.filter(text_id__isnull=False).values_list('text_id', flat=True)))
+
+        return id_list
+
+
+    def handle(self, *args, **options):
+        ids_dict = {
+            'purified': self.purified_translations(),
+            'linkified': self.linkified_translations(),
+        }
+
+        tasks = []
+        for meta_type, ids in ids_dict.items():
+            tasks.extend([clean_outgoing_urls.subtask(args=[chunk, meta_type, options['dry_run']])
+                     for chunk in chunked(ids, 100)])
+
+        group(tasks).apply_async()

--- a/src/olympia/translations/tasks.py
+++ b/src/olympia/translations/tasks.py
@@ -1,0 +1,58 @@
+from olympia.amo.decorators import use_primary_db
+from olympia.amo.celery import task
+from olympia.translations.models import PurifiedTranslation, LinkifiedTranslation
+import olympia.core.logger
+import settings
+
+log = olympia.core.logger.getLogger('z.task')
+
+
+@task
+@use_primary_db
+def clean_outgoing_urls(ids, meta_type, dry_run=True, **kw):
+    """Cleans up translation objects that need to be re-processed following a change in REDIRECT_URL"""
+    stats = {
+        'cleaned': 0,
+        'skipped': 0,
+        'failed': 0,
+    }
+
+    # The last known outgoing url from ticket #203 (https://github.com/thundernest/addons-server/issues/203)
+    known_old_outgoing_url = 'outgoing.prod.mozaws.net'
+    outgoing_url = settings.REDIRECT_URL
+
+    translations = []
+
+    if meta_type == 'purified':
+        translations = PurifiedTranslation.objects.filter(id__in=ids)
+    elif meta_type == 'linkified':
+        translations = LinkifiedTranslation.objects.filter(id__in=ids)
+    else:
+        log.warning("[translations.tasks.clean_outgoing_urls] Unknown translation meta type: {meta_type}. Skipping...").format(meta_type=meta_type)
+        return
+
+    for translation in translations:
+        # Ignore already cleaned urls
+        if outgoing_url and outgoing_url in translation.localized_string_clean:
+            stats['skipped'] += 1
+            continue
+
+        # Clean the old outgoing url from the translation
+        translation.clean()
+
+        if outgoing_url and outgoing_url in translation.localized_string_clean:
+            stats['cleaned'] += 1
+        elif not outgoing_url and known_old_outgoing_url not in translation.localized_string_clean:  # No real way to check for this
+            stats['cleaned'] += 1
+        else:
+            stats['failed'] += 1
+            continue
+
+        if not dry_run:
+            translation.save()
+
+    log.info("[translations.tasks.clean_outgoing_urls] Chunk finished with a total of {ids} translations processed. {cleaned} translations cleaned, {skipped} translations skipped, and {failed} translations failed.".format(ids=len(ids), cleaned=stats['cleaned'], skipped=stats['skipped'], failed=stats['failed']))
+
+    if dry_run:
+        log.info("[translations.tasks.clean_outgoing_urls] Dry run is enabled, no processed translations were saved.")
+


### PR DESCRIPTION
Fixes #203 

- Command can be run via `./manage.py clean_outgoing_urls [--dry-run]`
- `dry-run` does a test run, and does not save the cleaned results
- Stats are printed in task logger per each chunked run
- Note: Stats may not be correct on the second run through if REDIRECT_URL is falsey.
- Empty'd out the REDIRECT_URL strings for each conf (Any additional REDIRECT_URL is for tests)

There was an upstream fix, but it wouldn't really work since we want to remove the url, not change the url. Easier to just re-clean them. We can adjust the fields we want to clean, and I'm also not fixed on the stats, so we can nix those too if you'd like.

I ran this against 2000~ test addons locally, and the tasks run pretty much instantly. (Granted both my test machines are pretty beefy.) This needs a staging qa check, and we'll need to empty/none out any lingering `REDIRECT_URL` settings before running this.

Also I'm not impressed with whoever decided not to have a matching `meta_type` or `type` field on the translations table. :smile: 

