### PR TITLE
Allow GUID lookups in the admin panel (Fixes #228)

### DIFF
--- a/src/olympia/zadmin/templates/zadmin/includes/search_addons.html
+++ b/src/olympia/zadmin/templates/zadmin/includes/search_addons.html
@@ -1,4 +1,4 @@
 <form action="{{ url('zadmin.addon-search') }}" method="get" data-no-csrf>
-  <input type="search" name="q" value="{{ q|default('') }}" placeholder="name or id">
-    <p class="help">Type in names or ids to find an add-on. No auto-complete yet. Don't wrap numbers in braces.</p>
+  <input type="search" name="q" value="{{ q|default('') }}" placeholder="name, id, or guid">
+    <p class="help">Type in names, ids, or guids to find an add-on. No auto-complete yet. Don't wrap ids in braces.</p>
 </form>

--- a/src/olympia/zadmin/views.py
+++ b/src/olympia/zadmin/views.py
@@ -316,7 +316,10 @@ def addon_search(request):
         if q.isdigit():
             qs = Addon.objects.filter(id=int(q))
         else:
-            qs = Addon.search().query(name__text=q.lower())[:100]
+            # Try guid lookup first, and fallback to partial name search if we don't find anything
+            qs = Addon.objects.filter(guid=q)
+            if len(qs) == 0:
+                qs = Addon.search().query(name__text=q.lower())[:100]
         if len(qs) == 1:
             return redirect('zadmin.addon_manage', qs[0].id)
         ctx['addons'] = qs


### PR DESCRIPTION
Fixes #228 

We had a situation where someone needed to lookup by guid. While it's available in the api it's not in our admin tools, which I thought was odd. 

Not the most elegant if structure, but it works. Tested locally, and it looks good to me.