### PR TITLE
Add a cron task to automatically create a new app version from product details

### DIFF
--- a/scripts/crontab/crontab.tpl
+++ b/scripts/crontab/crontab.tpl
@@ -31,6 +31,7 @@ HOME=/tmp
 30 6 * * * %(z_cron)s deliver_hotness
 45 7 * * * %(django)s dump_apps
 0 8 * * * %(django)s update_product_details
+0 9 * * * %(django)s add_latest_appversion
 
 # Once per day after metrics import is done
 00 9 * * * %(z_cron)s update_addon_download_totals

--- a/src/olympia/amo/cron.py
+++ b/src/olympia/amo/cron.py
@@ -5,7 +5,7 @@ from subprocess import PIPE, Popen
 
 from django.conf import settings
 from django.core.files.storage import default_storage as storage
-from django.db import connection
+from django.db import connection, IntegrityError
 
 import waffle
 
@@ -15,16 +15,44 @@ from olympia import amo
 from olympia.activity.models import ActivityLog
 from olympia.amo.templatetags.jinja_helpers import user_media_path
 from olympia.amo.utils import chunked
+from olympia.applications.models import AppVersion
 from olympia.bandwagon.models import Collection
 from olympia.constants.base import VALID_ADDON_STATUSES, VALID_FILE_STATUSES
 from olympia.files.models import FileUpload
 from olympia.lib.akismet.models import AkismetReport
 from olympia.lib.es.utils import raise_if_reindex_in_progress
+from product_details import product_details
 
 from . import tasks
 
-
 log = olympia.core.logger.getLogger('z.cron')
+
+
+def add_latest_appversion(test_override_versions = None):
+    """Adds the latest Daily app versions of Thunderbird to ATN"""
+    version_info = product_details.thunderbird_versions if test_override_versions is None else test_override_versions
+    version_key = 'LATEST_THUNDERBIRD_NIGHTLY_VERSION'
+
+    main_version = version_info.get(version_key)
+    if not main_version or '.' not in main_version:
+        return
+
+    # Grab the major version and generate a `.0` and a `.*` version
+    major_number = main_version.split('.')[0]
+    if not major_number.isdigit():
+        log.debug('[add_latest_appversion] Major version {version} is not a number'.format(version=major_number))
+        return
+
+    base_major_version = "{major_number}.0".format(major_number=major_number)
+    any_major_version = "{major_number}.*".format(major_number=major_number)
+
+    versions = [main_version, base_major_version, any_major_version]
+
+    for version in versions:
+        try:
+            AppVersion.objects.create(application=amo.THUNDERBIRD.id, version=version)
+        except IntegrityError as e:
+            log.debug('[add_latest_appversion] Version {version} already exists: {err}'.format(version=version, err=e))
 
 
 def gc(test_result=True):

--- a/src/olympia/lib/settings_base.py
+++ b/src/olympia/lib/settings_base.py
@@ -1911,6 +1911,7 @@ CRON_JOBS = {
     'reindex_addons': 'olympia.addons.cron',
     'cleanup_image_files': 'olympia.addons.cron',
 
+    'add_latest_appversion': 'olympia.amo.cron',
     'gc': 'olympia.amo.cron',
     'category_totals': 'olympia.amo.cron',
     'weekly_downloads': 'olympia.amo.cron',


### PR DESCRIPTION
Fixes #237 

This adds a cron command to automatically generate appversions for Thunderbird via product details. 

Given a version, this will take the major number and generate two additional versions: `major_number.0` and `major_number.*`. If a version already exists, or if the major number if not a number, it will not create or update the version and move along.

Let me know if this needs to be tweaked.

I've added this to the crontab.tpl and settings, but I think that will have to be manually updated on the servers. 

I've ran the tests, but local ATN is a bit odd. So local testing was localized to just the tests. 🤷 
