### PR TITLE
Upgrade addons-linter to v6.15.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -90,4 +90,4 @@ ENV CLEANCSS_BIN /deps/node_modules/.bin/cleancss
 ENV LESS_BIN /deps/node_modules/.bin/lessc
 ENV UGLIFY_BIN /deps/node_modules/.bin/uglifyjs
 ENV ADDONS_LINTER_BIN /deps/node_modules/.bin/addons-linter
-RUN npm cache clean -f && npm install -g n && n 14.21
+RUN npm cache clean -f && npm install -g n && n 16

--- a/Dockerfile.deploy
+++ b/Dockerfile.deploy
@@ -99,5 +99,5 @@ RUN npm install \
     && make -f Makefile-docker copy_node_js \
     && DJANGO_SETTINGS_MODULE='settings_local' python manage.py compress_assets \
     && DJANGO_SETTINGS_MODULE='settings_local' python manage.py collectstatic --noinput
-RUN npm cache clean -f && npm install -g n && n 14.21
+RUN npm cache clean -f && npm install -g n && n 16
 RUN rm -f settings_local.py settings_local.pyc

--- a/package.json
+++ b/package.json
@@ -3,10 +3,10 @@
   "version": "0.0.17",
   "private": true,
   "engines": {
-    "node": ">= 14.21"
+    "node": ">= 16"
   },
   "dependencies": {
-    "addons-linter": "5.25.0",
+    "addons-linter": "~6.15.0",
     "clean-css": "4.2.3",
     "clean-css-cli": "4.3.0",
     "jqmodal": "1.4.2",


### PR DESCRIPTION
Fixes #249 

Ideally I'd like to upgrade to the latest version (or at least on the 6.*) (and we'll need too if we want to roll our own fork of addons-linter...) but that requires a minimum of node v16, and we're still on v14. 
https://github.com/mozilla/addons-linter/releases/tag/6.0.0 

So we'll roll the last 5 version, and manually enable manifest v3. From my local cli tests it works with the sample extensions, but I'd like to give this a staging test sometime next week.

EDIT:

I've upgraded to node v16, and addons-linter to v6.15.0 so we can test this on staging. 