### PR TITLE
update ATN submission email template

### DIFF
--- a/src/olympia/devhub/templates/devhub/email/submission.html
+++ b/src/olympia/devhub/templates/devhub/email/submission.html
@@ -1,23 +1,25 @@
-<p>Thanks for submitting your {{ addon_name }} add-on to <a href="https://addons.mozilla.org">addons.mozilla.org</a> (AMO)! Your add-on listing will go live shortly in our gallery here: <a href="{{ detail_url }}">{{ detail_url }}</a></p>
+<p>Thanks for submitting your {{ addon_name }} add-on to <a href="https://addons.thunderbird.net">addons.thunderbird.net</a> (ATN)! Your add-on listing will go live shortly in our gallery here: <a href="{{ detail_url }}">{{ detail_url }}</a></p>
 
 <p>Please keep in mind that while your add-on has been screened and approved for listing, other reviewers may look into it in the future and determine that it requires changes or should be removed from the gallery. If that occurs, you will receive a separate notification with details and next steps.</p>
 
-<p>For more information about the review process and policies, please visit <a href="https://developer.mozilla.org/Add-ons/AMO/Policy/Reviews">https://developer.mozilla.org/Add-ons/AMO/Policy/Reviews</a>.</p>
+<p>For more information about the review process and policies, please visit <a href="https://thunderbird.github.io/atn-review-policy/">https://thunderbird.github.io/atn-review-policy/</a>.</p>
 
 <hr />
 Attract Users, Stay Updated, &amp; Get in Touch
 <hr />
 
-<p>Add-ons help personalize the web experience for millions of users who have installed Firefox, and we want to help make your users happy!</p>
+<p>Add-ons help personalize the Email experience for millions of users who have installed Thunderbird, and we want to help make your users happy</p>
 
-<p>To learn how to help users discover your extension, stay up-to-date with news from the add-ons community, or contact the add-ons team, please visit <a href="https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/Distribution/Resources_for_publishers">https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/Distribution/Resources_for_publishers</a>.</p>>
+<p>Have a question about add-ons, the add-on review process or want to stay up-to-date with news from the add-ons community? Check out our community channels: <a href="https://developer.thunderbird.net/add-ons/community">https://developer.thunderbird.net/add-ons/community</a>.</p>
 
-<p>If you are interested in getting more involved with Mozilla and want to help keep the add-ons ecosystem safe and healthy, please consider becoming a volunteer add-on reviewer. You can learn more at <a href="https://wiki.mozilla.org/Add-ons/Reviewers">https://wiki.mozilla.org/Add-ons/Reviewers</a>.</p>
+<p>If you are interested in getting more involved with Thunderbird and want to help keep the add-ons ecosystem safe and healthy, please consider <a href="https://goo.gl/forms/1VkkaKJ0Mm39ph692"></a>becoming a volunteer add-on reviewer</a>.</p>
+
+If you want to get involved in the Thunderbird project itself, check out our "Get Involved" page: https://thunderbird.net/get-involved
 
 <p>Happy developing!</p>
 
 <p>
 -- <br/>
-Mozilla Add-ons<br/>
-<a href="https://addons.mozilla.org">https://addons.mozilla.org</a><br/>
+Thunderbird Team<br/>
+<a href="https://addons.thunderbird.net">https://addons.thunderbird.net</a><br/>
 </p>

--- a/src/olympia/devhub/templates/devhub/email/submission.html
+++ b/src/olympia/devhub/templates/devhub/email/submission.html
@@ -12,7 +12,7 @@ Attract Users, Stay Updated, &amp; Get in Touch
 
 <p>Have a question about add-ons, the add-on review process or want to stay up-to-date with news from the add-ons community? Check out our community channels: <a href="https://developer.thunderbird.net/add-ons/community">https://developer.thunderbird.net/add-ons/community</a>.</p>
 
-<p>If you are interested in getting more involved with Thunderbird and want to help keep the add-ons ecosystem safe and healthy, please consider <a href="https://goo.gl/forms/1VkkaKJ0Mm39ph692"></a>becoming a volunteer add-on reviewer</a>.</p>
+<p>If you are interested in getting more involved with Thunderbird and want to help keep the add-ons ecosystem safe and healthy, please consider <a href="https://goo.gl/forms/1VkkaKJ0Mm39ph692">becoming a volunteer add-on reviewer</a>.</p>
 
 If you want to get involved in the Thunderbird project itself, check out our "Get Involved" page: https://thunderbird.net/get-involved
 

--- a/src/olympia/devhub/templates/devhub/email/submission.txt
+++ b/src/olympia/devhub/templates/devhub/email/submission.txt
@@ -6,11 +6,9 @@ For more information about the review process and policies, please visit https:/
 
 ********
 
-********
-
 Add-ons help personalize the Email experience for millions of users who have installed Thunderbird, and we want to help make your users happy! 
 
-Have a question about add-ons or the add-on review process? You can join the add-on reviewers IRC channel at #tb-addon-reviewer on irc.mozilla.org or Email the add-on reviewers at: Tb-addon-reviewers@lists.thunderbird.net
+Have a question about add-ons, the add-on review process or want to stay up-to-date with news from the add-ons community? Check out our community channels: https://developer.thunderbird.net/add-ons/community.
 
 If you are interested in getting more involved with Thunderbird and want to help keep the add-ons ecosystem safe and healthy, please consider becoming a volunteer add-on reviewer. You can apply at: https://goo.gl/forms/1VkkaKJ0Mm39ph692 
 


### PR DESCRIPTION
Removes references to AMO in the HTML part of emails send to developers after submitting a new version. 

Also removes IRC channels listed in the TEXT part, replaced by a reference to https://developer.thunderbird.net/add-ons/community
