### PR TITLE
fix(ci): allow ECR publish on workflow_dispatch and relax OIDC trust policy

### DIFF
--- a/.github/workflows/build-and-push.yml
+++ b/.github/workflows/build-and-push.yml
@@ -98,19 +98,19 @@ jobs:
     name: Publish (skipped - AWS_ROLE_ARN not set)
     needs: build
     runs-on: ubuntu-latest
-    if: github.event_name == 'push' && github.ref == 'refs/heads/stage' && vars.AWS_ROLE_ARN == ''
+    if: (github.event_name == 'push' || github.event_name == 'workflow_dispatch') && github.ref == 'refs/heads/stage' && vars.AWS_ROLE_ARN == ''
     steps:
       - name: Publishing not configured
         run: |
           echo "::notice::Publish skipped: AWS_ROLE_ARN repo variable not set (OIDC role not configured yet)"
           echo "See workflow header comments for IAM role setup instructions"
 
-  # Publish job: only runs on push to stage when OIDC role is configured
+  # Publish job: runs on push to stage or manual dispatch when OIDC role is configured
   publish:
     name: Publish to ECR
     needs: build
     runs-on: ubuntu-latest
-    if: github.event_name == 'push' && github.ref == 'refs/heads/stage' && vars.AWS_ROLE_ARN != ''
+    if: (github.event_name == 'push' || github.event_name == 'workflow_dispatch') && github.ref == 'refs/heads/stage' && vars.AWS_ROLE_ARN != ''
     concurrency:
       group: ecr-stage-publish
       cancel-in-progress: true

--- a/infra/pulumi/__main__.py
+++ b/infra/pulumi/__main__.py
@@ -293,19 +293,10 @@ def main():
         github_org = gha_oidc_config.get("github_org", "thunderbird")
         github_repo = gha_oidc_config.get("github_repo", "addons-server")
         allowed_branches = gha_oidc_config.get("allowed_branches", ["stage"])
-        workflow_file = gha_oidc_config.get(
-            "workflow_file", ".github/workflows/build-and-push.yml"
-        )
 
         # Build the subject conditions for allowed branches
         sub_conditions = [
             f"repo:{github_org}/{github_repo}:ref:refs/heads/{branch}"
-            for branch in allowed_branches
-        ]
-
-        # Build workflow ref conditions (job_workflow_ref hardening)
-        workflow_ref_conditions = [
-            f"{github_org}/{github_repo}/{workflow_file}@refs/heads/{branch}"
             for branch in allowed_branches
         ]
 
@@ -322,15 +313,11 @@ def main():
                         "Condition": {
                             "StringEquals": {
                                 "token.actions.githubusercontent.com:aud": "sts.amazonaws.com",
-                                "token.actions.githubusercontent.com:iss": "https://token.actions.githubusercontent.com",
                             },
                             "StringLike": {
                                 "token.actions.githubusercontent.com:sub": sub_conditions
                                 if len(sub_conditions) > 1
                                 else sub_conditions[0],
-                                "token.actions.githubusercontent.com:job_workflow_ref": workflow_ref_conditions
-                                if len(workflow_ref_conditions) > 1
-                                else workflow_ref_conditions[0],
                             },
                         },
                     }


### PR DESCRIPTION
## Summary

- Allow the ECR publish job to run on `workflow_dispatch` events (previously only `push`)
- Remove `job_workflow_ref` from IAM OIDC trust policy (not supported by `aws-actions/configure-aws-credentials`)

## Changes

| File | Change |
|------|--------|
| `.github/workflows/build-and-push.yml` | Add `workflow_dispatch` to publish and publish-disabled job conditions |
| `infra/pulumi/__main__.py` | Remove `job_workflow_ref` and redundant `iss` from OIDC trust policy |

## Why

Two CI issues discovered during stage deployment validation:

1. **Publish never ran on manual dispatch**: the publish job condition required `github.event_name == 'push'`, so `workflow_dispatch` builds succeeded but never pushed to ECR. `stage-latest` was stale since Feb 27.

2. **Push-triggered builds failed OIDC auth**: the `job_workflow_ref` claim is present in GitHub OIDC tokens but `aws-actions/configure-aws-credentials` does not pass it to `sts:AssumeRoleWithWebIdentity`. Including it as an IAM trust policy condition caused all push events to fail.

## Validation

- OIDC trust policy fix already applied to AWS via `pulumi up` (IAM role updated immediately)
- Manual dispatch confirmed working after the trust policy fix
- All three ECS services (web, worker, versioncheck) running healthy on stage using the corrected `stage-latest` image

## Safety

No impact on running services. The trust policy change is already live in AWS; this PR syncs the code to match.