### PR TITLE
fix(uwsgi): add static-map for static files and user-media uploads

### DIFF
--- a/docker/docker-entrypoint.sh
+++ b/docker/docker-entrypoint.sh
@@ -98,6 +98,8 @@ start_web() {
         --disable-write-exception \
         --log-5xx \
         --log-slow=1000 \
+        --static-map=/static=/data/olympia/site-static/ \
+        --static-map=/user-media=${NETAPP_STORAGE_ROOT:-/tmp/storage}/shared_storage/uploads/ \
         --stats=:9191 \
         --stats-http \
         "$@"


### PR DESCRIPTION
## Summary

- Add uWSGI `--static-map` directives to the Fargate entrypoint for `/static/` and `/user-media/` paths
- Fixes 404 errors on all static assets reported after DNS cutover to ECS

## Changes

| File | Change |
|------|--------|
| `docker/docker-entrypoint.sh` | Add `--static-map=/static` and `--static-map=/user-media` to `start_web()` uWSGI command |

## Why

The legacy EC2 setup uses `olympia.ini` with `static-map` directives to serve static files and user-uploaded media directly from uWSGI. Our Fargate entrypoint did not carry these over, resulting in 404s for all `/static/` and `/user-media/` paths.

Reference: `thundernest-ansible/addons/olympia.ini` lines 55-56.

## Validation

- Confirmed the exact `static-map` paths match the Ansible config
- `/static/` maps to `/data/olympia/site-static/` (built into the Docker image)
- `/user-media/` maps to `$NETAPP_STORAGE_ROOT/shared_storage/uploads/` (falls back to `/tmp/storage` when EFS is not mounted)

## Safety

No impact on running services until the new image is deployed. Static file serving is read-only by nature.

## Follow-up

EFS mount targets and task definition volumes for persistent user-media storage will be addressed in a separate infrastructure PR.