### PR TITLE
fix(uwsgi): add cache headers, redirects,  et al., from olympia.ini

### DIFF
--- a/docker/docker-entrypoint.sh
+++ b/docker/docker-entrypoint.sh
@@ -100,6 +100,16 @@ start_web() {
         --log-slow=1000 \
         --static-map=/static=/data/olympia/site-static/ \
         --static-map=/user-media=${NETAPP_STORAGE_ROOT:-/tmp/storage}/shared_storage/uploads/ \
+        --static-safe=${NETAPP_STORAGE_ROOT:-/tmp/storage}/shared_storage/uploads/ \
+        --static-safe=${NETAPP_STORAGE_ROOT:-/tmp/storage}/files/ \
+        --static-expires=/* 7776000 \
+        --route-if="equal:\${HTTP_X_FORWARDED_PROTO};http redirect-permanent:https://addons-stage.thunderbird.net\${REQUEST_URI}" \
+        --route-uri="^/([a-z]{2,3})(-[A-Z]{2,3})?/(firefox|android)/(.*) redirect-302:https://addons.mozilla.org/\$1\$2/\$3/\$4" \
+        --route-uri="^/user-media/addons/_attachments/(.*) addheader:Content-Disposition: attachment" \
+        --collect-header="X-Accel-Redirect X_SENDFILE" \
+        --collect-header="Content-Disposition SENDFILE_CONTENT" \
+        --response-route-if-not="empty:\${X_SENDFILE} addheader:Content-Disposition:\${SENDFILE_CONTENT}" \
+        --response-route-if-not="empty:\${X_SENDFILE} static:\${X_SENDFILE}" \
         --stats=:9191 \
         --stats-http \
         "$@"


### PR DESCRIPTION
## Summary

- Port remaining uWSGI file-serving settings from the Ansible config (`olympia.ini`)
- Adds cache headers, HTTP-to-HTTPS redirect, Firefox/Android redirect, attachment headers, and sendfile support

## Changes

| File | Change |
|------|--------|
| `docker/docker-entrypoint.sh` | Add static-safe, static-expires, route-if, route-uri, collect-header, and response-route directives to `start_web()` |

## Why

PR #372 fixed the immediate static file 404s with `--static-map`. This PR carries over the remaining uWSGI settings from `thundernest-ansible/addons/olympia.ini` that affect performance and behaviour:

- `static-expires`: 90-day cache headers (addresses reported slowness)
- `static-safe`: allows serving user-media uploads and add-on files
- `route-if`: HTTP-to-HTTPS redirect
- `route-uri`: redirects Firefox/Android paths to addons.mozilla.org
- `route-uri`: content-disposition header for attachment downloads
- `collect-header` and `response-route-if-not`: X-Accel-Redirect sendfile for efficient large file serving

Reference: thundernest-ansible/addons/olympia.ini lines 55-67

## Safety

No impact on running services until the new image is deployed. All settings are read-only file serving behaviour.

## Follow-up

EFS mount targets (separate PR) will provide the actual persistent storage behind the user-media and files paths.